### PR TITLE
Redhat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,50 @@ You have different possibile approaches in the usage of this module.
           "224" : "isp2"
         }
 
+###Route and Rule Configuration
+
+For routes and rules there are two methods of invocation of the module due to differences in how RedHat and Debian store the configurations on disk. RedHat uses a per device configuration while Debian has a unified configuration.
+
+###Debian
+
 * Add routes :
 
          routes_hash => [
           {'network' => '1.2.3.0/24', 'gateway' => '10.0.0.1', 'table' => 'isp1'},
-          {'network' => '1.2.4.0/24', 'gateway' => '10.0.0.2', 'table' => 'isp2'}]
-         }
+          {'network' => '1.2.4.0/24', 'gateway' => '10.0.0.2', 'table' => 'isp2'}
+         ]
 
 * Add rules :
 
         rules_hash => [{'from' => '1.2.3.4', 'to' => '0.0.0.0/0', 'table' => 'isp1', 'priority' => '1000' }],
 
+
+###RedHat
+
+You need to specify the interface/dev as a top level key in the hash
+
+* add routes :
+
+         routes_hash => [
+          'eth0' => [ {'network' => '1.2.3.0/24', 'gateway' => '10.0.0.1', 'table' => 'isp1'},
+                      {'network' => '1.2.4.0/24', 'gateway' => '10.0.0.2', 'table' => 'isp2'}
+                    ],
+          'eth1' => [ {'network' => '1.2.3.0/24', 'gateway' => '10.0.0.1', 'table' => 'isp1'},
+                      {'network' => '1.2.4.0/24', 'gateway' => '10.0.0.2', 'table' => 'isp2'}
+                    ]
+          ]
+
+* Add rules :
+
+        rules_hash => [
+          'eth0' => [{'from' => '1.2.3.4', 'to' => '0.0.0.0/0', 'table' => 'isp1', 'priority' => '1000' } ]
+        ]
+
+
 ##Operating Systems Support
 
 This is tested on these OS:
-- Debian 7
+- Debian 7, Scientific Linux
 
 ##Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,32 +11,32 @@
 
 # Add rt_tables / rt_protos
 class iproute2 (
-$rt_tables_hash = undef,
-$rt_protos_hash = undef,
-$rules_hash  = undef,
-$routes_hash = undef,
+  $rt_tables_hash = undef,
+  $rt_protos_hash = undef,
+  $rules_hash  = undef,
+  $routes_hash = undef,
 ){
   if $rt_tables_hash {
     iproute2::rt_tables { 'rt_tables' :
-    rt_tables => $rt_tables_hash
+      rt_tables => $rt_tables_hash
+    }
   }
- }
   if $rt_protos_hash {
     iproute2::rt_protos { 'rt_protos' :
-    rt_protos => $rt_protos_hash
+      rt_protos => $rt_protos_hash
+    }
   }
- }
 
 # Create boot script routes
   if $routes_hash {
     iproute2::routes { 'routes' :
-    routes => $routes_hash
+      routes => $routes_hash
+    }
   }
- }
 # Create boot script rules
   if $rules_hash {
     iproute2::rules { 'rules' :
-    rules => $rules_hash
+      rules => $rules_hash
+    }
   }
- }
 }

--- a/manifests/redhat_routes.pp
+++ b/manifests/redhat_routes.pp
@@ -1,0 +1,21 @@
+#
+# = Define: iproute2::redhat_setup
+#
+# == Common parameters
+#
+#  $routes = {"id" : "name"}
+
+define iproute2::redhat_routes(
+  $routes_hash
+){
+  $dev = $name
+  $routes = $routes_hash[$dev]
+
+  file { "/etc/sysconfig/network-scripts/route-${dev}":
+    ensure  => present,
+    content => template('iproute2/etc/sysconfig/network-scripts/route.erb'),
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+  }
+}

--- a/manifests/redhat_rules.pp
+++ b/manifests/redhat_rules.pp
@@ -1,0 +1,21 @@
+#
+# = Define: iproute2::redhat_setup
+#
+# == Common parameters
+#
+#  $routes = {"id" : "name"}
+
+define iproute2::redhat_rules(
+  $rules_hash,
+){
+  $dev = $name
+  $rules = $rules_hash[$dev]
+
+  file { "/etc/sysconfig/network-scripts/rule-${dev}":
+    ensure  => present,
+    content => template('iproute2/etc/sysconfig/network-scripts/rule.erb'),
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+  }
+}

--- a/manifests/routes.pp
+++ b/manifests/routes.pp
@@ -9,20 +9,26 @@
 #  $routes = {"id" : "name"}
 
 define iproute2::routes(
-$routes = {},
+  $routes = {},
 ){
   case $::osfamily {
-        'Debian': {
-            file { '/etc/network/if-up.d/iproute2-001-routes':
-            ensure  => present,
-            content => template('iproute2/etc/network/if-up.d/iproute2-001-routes-Debian.erb'),
-            mode    => '0755',
-            owner   => 'root',
-            group   => 'root',
-        }
+    'Debian': {
+      file { '/etc/network/if-up.d/iproute2-001-routes':
+        ensure  => present,
+        content => template('iproute2/etc/network/if-up.d/iproute2-001-routes-Debian.erb'),
+        mode    => '0755',
+        owner   => 'root',
+        group   => 'root',
+      }
     }
-        default: {
-            alert("${::operatingsystem} not supported. No changes done here.")
-        }
+    'RedHat': {
+      $devs = keys($routes)
+      ::iproute2::redhat_routes { $devs :
+        routes_hash => $routes,
+      }
+    }
+    default: {
+      alert("${::operatingsystem} not supported. No changes done here.")
+    }
   }
 }

--- a/manifests/rt_protos.pp
+++ b/manifests/rt_protos.pp
@@ -9,20 +9,29 @@
 #  $rt_protos = {"id" : "name"}
 
 define iproute2::rt_protos(
-$rt_protos = {},
+  $rt_protos = {},
 ){
   case $::osfamily {
-        'Debian': {
-            file { '/etc/iproute2/rt_protos':
-            ensure  => present,
-            content => template('iproute2/etc/iproute2/rt_protos-Debian.erb'),
-            mode    => '0644',
-            owner   => 'root',
-            group   => 'root',
-        }
+    'Debian': {
+      file { '/etc/iproute2/rt_protos':
+        ensure  => present,
+        content => template('iproute2/etc/iproute2/rt_protos-Debian.erb'),
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+      }
     }
-        default: {
-            alert("${::operatingsystem} not supported. No changes done here.")
-        }
+    'RedHat': {
+      file { '/etc/iproute2/rt_protos':
+        ensure  => present,
+        content => template('iproute2/etc/iproute2/rt_protos-RedHat.erb'),
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+      }
+    }
+    default: {
+      alert("${::operatingsystem} not supported. No changes done here.")
+    }
   }
 }

--- a/manifests/rt_tables.pp
+++ b/manifests/rt_tables.pp
@@ -9,20 +9,29 @@
 #  $rt_tables = {"id" : "name"}
 
 define iproute2::rt_tables(
-$rt_tables = {},
+  $rt_tables = {},
 ){
   case $::osfamily {
-        'Debian': {
-            file { '/etc/iproute2/rt_tables':
-            ensure  => present,
-            content => template('iproute2/etc/iproute2/rt_tables-Debian.erb'),
-            mode    => '0644',
-            owner   => 'root',
-            group   => 'root',
-        }
+    'Debian': {
+      file { '/etc/iproute2/rt_tables':
+        ensure  => present,
+        content => template('iproute2/etc/iproute2/rt_tables-Debian.erb'),
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+      }
     }
-        default: {
-            alert("${::operatingsystem} not supported. No changes done here.")
-        }
+    'RedHat': {
+      file { '/etc/iproute2/rt_tables':
+        ensure  => present,
+        content => template('iproute2/etc/iproute2/rt_tables-RedHat.erb'),
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+      }
+    }
+    default: {
+      alert("${::operatingsystem} not supported. No changes done here.")
+    }
   }
 }

--- a/manifests/rules.pp
+++ b/manifests/rules.pp
@@ -9,20 +9,26 @@
 #  $rules = {"id" : "name"}
 
 define iproute2::rules(
-$rules = {},
+  $rules = {},
 ){
   case $::osfamily {
-        'Debian': {
-            file { '/etc/network/if-up.d/iproute2-002-rules':
-            ensure  => present,
-            content => template('iproute2/etc/network/if-up.d/iproute2-002-rules-Debian.erb'),
-            mode    => '0755',
-            owner   => 'root',
-            group   => 'root',
-        }
+    'Debian': {
+      file { '/etc/network/if-up.d/iproute2-002-rules':
+        ensure  => present,
+        content => template('iproute2/etc/network/if-up.d/iproute2-002-rules-Debian.erb'),
+        mode    => '0755',
+        owner   => 'root',
+        group   => 'root',
+      }
     }
-        default: {
-            alert("${::operatingsystem} not supported. No changes done here.")
-        }
+    'RedHat': {
+      $devs = keys($rules)
+      ::iproute2::redhat_rules { $devs :
+        rules_hash => $rules,
+      }
+    }
+    default: {
+      alert("${::operatingsystem} not supported. No changes done here.")
+    }
   }
 }

--- a/templates/etc/iproute2/rt_protos-RedHat.erb
+++ b/templates/etc/iproute2/rt_protos-RedHat.erb
@@ -1,0 +1,41 @@
+###
+### File managed by Puppet
+###
+
+#
+# Reserved protocols.
+#
+0	unspec
+1	redirect
+2	kernel
+3	boot
+4	static
+8	gated
+9	ra
+10	mrt
+11	zebra
+12	bird
+13	dnrouted
+14	xorp
+15	ntk
+16      dhcp
+
+#
+#	Used by me for gated
+#
+254	gated/aggr
+253	gated/bgp
+252	gated/ospf
+251	gated/ospfase
+250	gated/rip
+249	gated/static
+248	gated/conn
+247	gated/inet
+246	gated/default
+
+#
+# local
+#
+<% @rt_protos.each do |key,value| -%>
+<%= key %>	<%= value %>
+<% end -%>

--- a/templates/etc/iproute2/rt_tables-RedHat.erb
+++ b/templates/etc/iproute2/rt_tables-RedHat.erb
@@ -1,0 +1,18 @@
+###
+### File managed by Puppet
+###
+
+#
+# reserved values
+#
+255	local
+254	main
+253	default
+0	unspec
+
+#
+# local
+#
+<% @rt_tables.each do |key,value| -%>
+<%= key %>	<%= value %>
+<% end -%>

--- a/templates/etc/sysconfig/network-scripts/route.erb
+++ b/templates/etc/sysconfig/network-scripts/route.erb
@@ -1,0 +1,6 @@
+###
+### File managed by Puppet
+###
+<% @routes.each do |value| -%>
+<%= value['network'] %><%if value.has_key?('gateway') %> via <%= value['gateway'] %><% end %> <%if value.has_key?('dev') %>dev <%= value['dev'] %><% end %><%if value.has_key?('src') %> src <%= value['src'] %><% end %>table <%= value['table'] %><%if value.has_key?('mtu') %> mtu <%= value['mtu'] %><% end %>
+<% end -%>

--- a/templates/etc/sysconfig/network-scripts/rule.erb
+++ b/templates/etc/sysconfig/network-scripts/rule.erb
@@ -1,0 +1,6 @@
+###
+### File managed by Puppet
+###
+<% @rules.each do |value| -%>
+from <%= value['from'] %><% if value.has_key?('to') %> to <%= value['to'] %><% end %> table <%= value['table'] %><% if value.has_key?('priority') %> priority <%= value['priority'] %><% end %>
+<% end -%>


### PR DESCRIPTION
I have added RedHat type OS support (RHEL, Centos, Scientific Linux) to the module for our use. RedHat has a different way of doing the route and rule configurations with its network scripts so I had to have an alternate hash format in that case. Let me know what you think or changes you suggest.

I also adjusted some indentation for consistency to pass our linter. 
