### PR TITLE
Add support for IPv6 and fwmark-based rules in Debian

### DIFF
--- a/templates/etc/network/if-up.d/iproute2-002-rules-Debian.erb
+++ b/templates/etc/network/if-up.d/iproute2-002-rules-Debian.erb
@@ -8,5 +8,5 @@
 <% else %>
 [ "$IFACE" != "lo" ] || exit 0
 <% end %>
-/sbin/ip <% if value['ipv6'] -%>-6<% end -%> rule add from <%= value['from'] %><% if value.has_key?('to') %> to <%= value['to'] %><% end %> table <%= value['table'] %><% if value.has_key?('priority') %> priority <%= value['priority'] %><% end %>
+/sbin/ip <% if value['ipv6'] -%>-6<% end -%> rule add <% if value.has_key?('fwmark') %> fwmark <%= value['fwmark'] %><% end -%><% if value.has_key?('from') %> from <%= value['from'] %><% end -%><% if value.has_key?('to') %> to <%= value['to'] %><% end %> table <%= value['table'] %><% if value.has_key?('priority') %> priority <%= value['priority'] %><% end %>
 <% end -%>

--- a/templates/etc/network/if-up.d/iproute2-002-rules-Debian.erb
+++ b/templates/etc/network/if-up.d/iproute2-002-rules-Debian.erb
@@ -8,5 +8,5 @@
 <% else %>
 [ "$IFACE" != "lo" ] || exit 0
 <% end %>
-/sbin/ip rule add from <%= value['from'] %><% if value.has_key?('to') %> to <%= value['to'] %><% end %> table <%= value['table'] %><% if value.has_key?('priority') %> priority <%= value['priority'] %><% end %>
+/sbin/ip <% if value['ipv6'] -%>-6<% end -%> rule add from <%= value['from'] %><% if value.has_key?('to') %> to <%= value['to'] %><% end %> table <%= value['table'] %><% if value.has_key?('priority') %> priority <%= value['priority'] %><% end %>
 <% end -%>


### PR DESCRIPTION
Hello,

These commits extend the rules functionality to include rules based on fwmark and IPv6 rules.
