### PR TITLE
Add some required whitespace between parameters in RedHat templates

### DIFF
--- a/templates/etc/sysconfig/network-scripts/route.erb
+++ b/templates/etc/sysconfig/network-scripts/route.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <% @routes.each do |value| -%>
-<%= value['network'] %><%if value.has_key?('gateway') %> via <%= value['gateway'] %><% end %> <%if value.has_key?('dev') %>dev <%= value['dev'] %><% end %><%if value.has_key?('src') %> src <%= value['src'] %><% end %>table <%= value['table'] %><%if value.has_key?('mtu') %> mtu <%= value['mtu'] %><% end %>
+<%= value['network'] %> <%if value.has_key?('gateway') %>via <%= value['gateway'] %> <% end %><%if value.has_key?('dev') %>dev <%= value['dev'] %> <% end %><%if value.has_key?('src') %>src <%= value['src'] %> <% end %>table <%= value['table'] %><%if value.has_key?('mtu') %> mtu <%= value['mtu'] %><% end %>
 <% end -%>

--- a/templates/etc/sysconfig/network-scripts/rule.erb
+++ b/templates/etc/sysconfig/network-scripts/rule.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <% @rules.each do |value| -%>
-from <%= value['from'] %><% if value.has_key?('to') %> to <%= value['to'] %><% end %> table <%= value['table'] %><% if value.has_key?('priority') %> priority <%= value['priority'] %><% end %>
+<% if value.has_key?('from') %>from <%= value['from'] %> <% end -%><% if value.has_key?('to') %>to <%= value['to'] %> <% end %>table <%= value['table'] %><% if value.has_key?('priority') %> priority <%= value['priority'] %><% end %>
 <% end -%>


### PR DESCRIPTION
Add required whitespace around params that were missing it (if a route with 'dev' was used, it did not have the required trailing whitespace and was mashed into the following 'table' directive).

Add a conditional around 'from' in the rules template.
